### PR TITLE
DMD-395: Allow disconnected signals

### DIFF
--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -2,7 +2,7 @@ import logging
 import datetime
 
 from django.conf import settings
-from django.db.models import F
+from django.db.models import F, signals
 from django.db.utils import IntegrityError, DataError
 from django.core.exceptions import FieldDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
@@ -67,6 +67,16 @@ class Command(BaseCommand):
             logger.info('Scrubbing %s with %s', model._meta.label, realized_scrubbers)
 
             options = dict(_get_options(model))
+
+            if "disconnect_signals" in options:
+                disconnect_signals = options["disconnect_signals"]
+
+                for signal_data in disconnect_signals:
+                    model_signal = getattr(signals, signal_data["type"])
+                    model_signal.disconnect(
+                        sender=signal_data["sender"],
+                        dispatch_uid=signal_data["dispatch_uid"],
+                    )
 
             if 'trim_table' in options:
                 filter_kwargs = {options['trim_attribute'] + '__gte': datetime.datetime.now() - datetime.timedelta(days=30)}

--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -68,14 +68,14 @@ class Command(BaseCommand):
 
             options = dict(_get_options(model))
 
-            if "disconnect_signals" in options:
-                disconnect_signals = options["disconnect_signals"]
+            if 'disconnect_signals' in options:
+                disconnect_signals = options['disconnect_signals']
 
                 for signal_data in disconnect_signals:
-                    model_signal = getattr(signals, signal_data["type"])
+                    model_signal = getattr(signals, signal_data['type'])
                     model_signal.disconnect(
-                        sender=signal_data["sender"],
-                        dispatch_uid=signal_data["dispatch_uid"],
+                        sender=signal_data['sender'],
+                        dispatch_uid=signal_data['dispatch_uid'],
                     )
 
             if 'trim_table' in options:


### PR DESCRIPTION
Allow signals to be disconnected before running `scrub_data` command.

FYI tested this locally with a subset of the order data and it worked.